### PR TITLE
update(AUTHORS.md): Add jessefeinman as an author

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,3 +1,5 @@
 This library was developed by many exceptional engineers at X/Twitter from 2015 onwards.
 
+- [Jesse Feinman](https://github.com/jessefeinman)
+
 If you contributed to this library and would like to be included in the Authors list please submit a pull request or reach out directly.


### PR DESCRIPTION
### Problem

Jesse Feinman was an active contributor to the Stitch library for several years and is not listed in the AUTHORS.md authors listed

### Solution

Add Jesse Feinman, @jessefeinman, to the authors list.

### Result

Jesse Feinman is now added as an author.